### PR TITLE
Merge pull request from JeanMertz/fix-duplicate-fields 

### DIFF
--- a/core.go
+++ b/core.go
@@ -121,7 +121,7 @@ func (c *core) Write(ent zapcore.Entry, fields []zapcore.Field) error {
 	c.tempLabels.mutex.Unlock()
 	lbls.mutex.RUnlock()
 
-	fields = append(fields, labelsField(c.allLabels()))
+	fields = mergeLabelFields(fields, c.allLabels())
 	fields = c.withSourceLocation(ent, fields)
 	if c.config.ServiceName != "" {
 		fields = c.withServiceContext(c.config.ServiceName, fields)

--- a/core_test.go
+++ b/core_test.go
@@ -180,6 +180,28 @@ func TestWrite(t *testing.T) {
 	assert.NotNil(t, logs.All()[0].ContextMap()[labelsKey])
 }
 
+// ref: https://github.com/blendle/zapdriver/issues/29
+func TestWriteDuplicateLabels(t *testing.T) {
+	debugcore, logs := observer.New(zapcore.DebugLevel)
+	core := &core{
+		Core:       debugcore,
+		permLabels: newLabels(),
+		tempLabels: newLabels(),
+	}
+
+	fields := []zap.Field{
+		Labels(
+			Label("hello", "world"),
+			Label("hi", "universe"),
+		),
+	}
+
+	err := core.Write(zapcore.Entry{}, fields)
+	require.NoError(t, err)
+
+	assert.Len(t, logs.All()[0].Context, 1)
+}
+
 func TestWriteConcurrent(t *testing.T) {
 	temp := newLabels()
 	temp.store = map[string]string{"one": "1", "two": "2"}


### PR DESCRIPTION
Prevent duplicate labels fields.

Fixes https://github.com/blendle/zapdriver/issues/29.